### PR TITLE
Updates Gitlab icon

### DIFF
--- a/hub/gitlab.yaml
+++ b/hub/gitlab.yaml
@@ -4,7 +4,7 @@ dockerfile: src/gitlab/Dockerfile
 branch: main
 displayName: Gitlab
 url: https://gitlab.com/-/user_settings/personal_access_tokens?page=1
-icon: hhttps://avatars.githubusercontent.com/u/1086321?s=200&v=4
+icon: https://avatars.githubusercontent.com/u/1086321?s=200&v=4
 description: Search repos, files and issues, and commit in Gitlab
 longDescription: Search repos, files and issues, and commit in Gitlab
 disabled: true


### PR DESCRIPTION
Updates the Gitlab icon to use a new, more visually appropriate and consistently accessible image. The previous icon URL was less reliable.