### PR TITLE
Fixes Gitlab integration and simplifies Docker build

### DIFF
--- a/dockerfiles/gitlab.Dockerfile
+++ b/dockerfiles/gitlab.Dockerfile
@@ -1,0 +1,26 @@
+FROM node:22.12-alpine AS builder
+
+COPY src/gitlab /app
+COPY tsconfig.json /tsconfig.json
+
+WORKDIR /app
+
+RUN --mount=type=cache,target=/root/.npm npm install
+
+RUN --mount=type=cache,target=/root/.npm-production npm ci --ignore-scripts --omit-dev
+
+FROM node:22.12-alpine AS release
+
+WORKDIR /app
+
+COPY --from=builder /app/dist /app/dist
+COPY --from=builder /app/package.json /app/package.json
+COPY --from=builder /app/package-lock.json /app/package-lock.json
+
+ENV NODE_ENV=production
+
+RUN apk add --no-cache git
+RUN npm ci --ignore-scripts --omit-dev
+RUN npm install -g pnpm
+RUN pnpm install https://github.com/blaxel-ai/supergateway
+ENTRYPOINT ["npx","-y","@blaxel/supergateway","--port","80","--stdio"]

--- a/dockerfiles/sequentialthinking.Dockerfile
+++ b/dockerfiles/sequentialthinking.Dockerfile
@@ -1,0 +1,27 @@
+FROM node:22.12-alpine AS builder
+
+COPY src/sequentialthinking /app
+COPY tsconfig.json /tsconfig.json
+
+WORKDIR /app
+
+RUN --mount=type=cache,target=/root/.npm npm install
+
+RUN --mount=type=cache,target=/root/.npm-production npm ci --ignore-scripts --omit-dev
+
+FROM node:22-alpine AS release
+
+COPY --from=builder /app/dist /app/dist
+COPY --from=builder /app/package.json /app/package.json
+COPY --from=builder /app/package-lock.json /app/package-lock.json
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+RUN npm ci --ignore-scripts --omit-dev
+
+RUN apk add --no-cache git
+RUN npm install -g pnpm
+RUN pnpm install https://github.com/blaxel-ai/supergateway
+ENTRYPOINT ["npx","-y","@blaxel/supergateway","--port","80","--stdio"]

--- a/hub/gitlab.yaml
+++ b/hub/gitlab.yaml
@@ -1,13 +1,11 @@
 repository: https://github.com/smithery-ai/reference-servers.git
-dockerfile: src/gitlab/Dockerfile
+dockerfile: "@mcp-hub"
 branch: main
 displayName: Gitlab
 url: https://gitlab.com/-/user_settings/personal_access_tokens?page=1
 icon: https://avatars.githubusercontent.com/u/1086321?s=200&v=4
 description: Search repos, files and issues, and commit in Gitlab
 longDescription: Search repos, files and issues, and commit in Gitlab
-disabled: true
-comingSoon: true
 secrets:
   - gitlabPersonalAccessToken
 categories:

--- a/hub/sequentialthinking.yaml
+++ b/hub/sequentialthinking.yaml
@@ -1,5 +1,5 @@
 repository: https://github.com/smithery-ai/reference-servers.git
-dockerfile: src/sequentialthinking/Dockerfile
+dockerfile: "@mcp-hub"
 branch: main
 displayName: Sequential Thinking
 url: https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking


### PR DESCRIPTION
Addresses issues with Gitlab integration and streamlines the Docker build process:

- Updates the Gitlab hub configuration to use the MCP Hub for the Dockerfile, simplifying the build process and likely pulling from a prebuilt image.
- Adds a Dockerfile for Gitlab to build a functional Gitlab integration. This likely resolves a previous lack of proper Dockerfile configuration, ensuring the Gitlab integration can be deployed and run correctly.
- Includes a submodule update reflecting changes in a referenced repository.

These changes improve the reliability and usability of the Gitlab integration.