### PR TITLE
Fixes Gitlab integration and simplifies Docker build

### DIFF
--- a/dockerfiles/notion.Dockerfile
+++ b/dockerfiles/notion.Dockerfile
@@ -6,13 +6,13 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Copy the package.json and package-lock.json files
-COPY notion/package.json notion/package-lock.json ./
+COPY package.json package-lock.json ./
 
 # Install the dependencies
 RUN npm install --ignore-scripts
 
 # Copy the rest of the application source code
-COPY notion ./
+COPY . ./
 
 # Build the application
 RUN npm run build


### PR DESCRIPTION
Addresses issues with Gitlab integration and streamlines the Docker build process:

- Updates the Gitlab hub configuration to use the MCP Hub for the Dockerfile, simplifying the build process and likely pulling from a prebuilt image.
- Adds a Dockerfile for Gitlab to build a functional Gitlab integration. This likely resolves a previous lack of proper Dockerfile configuration, ensuring the Gitlab integration can be deployed and run correctly.
- Includes a submodule update reflecting changes in a referenced repository.

These changes improve the reliability and usability of the Gitlab integration.