### PR TITLE
Support constrained HTTP MCP upstream imports

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -125,9 +125,14 @@ func processRepository(name string, repository *hub.Repository) (*catalog.Catalo
 	}
 
 	buildTo := fmt.Sprintf("%s/%s", strings.ToLower(registry), imageName)
+	superGatewayArgs, err := repository.HTTPUpstream.SuperGatewayArgs()
+	if err != nil {
+		return nil, fmt.Errorf("http upstream super-gateway args: %w", err)
+	}
+
 	if !skipBuild {
 		deps := manageDeps(repository)
-		if err := buildAndPushImage(cfg, name, repository.SmitheryPath, repoPath, strings.TrimSuffix(repository.Dockerfile, "/Dockerfile"), buildTo, deps); err != nil {
+		if err := buildAndPushImage(cfg, name, repository.SmitheryPath, repoPath, strings.TrimSuffix(repository.Dockerfile, "/Dockerfile"), buildTo, deps, superGatewayArgs); err != nil {
 			return nil, fmt.Errorf("build and push image: %w", err)
 		}
 	}
@@ -140,14 +145,14 @@ func processRepository(name string, repository *hub.Repository) (*catalog.Catalo
 	return &c, nil
 }
 
-func buildAndPushImage(cfg *smithery.SmitheryConfig, name string, smitheryPath string, repoPath string, dockerfileDir string, imageName string, deps []string) error {
+func buildAndPushImage(cfg *smithery.SmitheryConfig, name string, smitheryPath string, repoPath string, dockerfileDir string, imageName string, deps []string, superGatewayArgs []string) error {
 	dockerfilePath, err := docker.Inject(
 		context.Background(),
 		name,
 		repoPath,
 		dockerfileDir,
 		dockerfile,
-		cfg.ParsedCommand.Entrypoint(),
+		cfg.ParsedCommand.Entrypoint(superGatewayArgs),
 		deps,
 	)
 	if err != nil {

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -54,9 +54,10 @@ type OAuth struct {
 }
 
 type Entrypoint struct {
-	Command string            `json:"command"`
-	Args    []string          `json:"args"`
-	Env     map[string]string `json:"env"`
+	Command          string            `json:"command"`
+	Args             []string          `json:"args"`
+	Env              map[string]string `json:"env"`
+	SuperGatewayArgs []string          `json:"superGatewayArgs,omitempty"`
 }
 
 type Catalog struct {
@@ -188,7 +189,16 @@ func (c *Catalog) Load(name string, hub *hub.Repository, imageName string, smith
 		hub.Integration = name
 	}
 	if hub.Transport == "" {
-		hub.Transport = "websocket"
+		if hub.HTTPUpstream != nil {
+			hub.Transport = "http-stream"
+		} else {
+			hub.Transport = "websocket"
+		}
+	}
+
+	superGatewayArgs, err := hub.HTTPUpstream.SuperGatewayArgs()
+	if err != nil {
+		return fmt.Errorf("http upstream super-gateway args: %w", err)
 	}
 
 	artifact := Artifact{
@@ -207,9 +217,10 @@ func (c *Catalog) Load(name string, hub *hub.Repository, imageName string, smith
 			OAuth:   oauth,
 		},
 		Entrypoint: Entrypoint{
-			Command: smithery.ParsedCommand.Command,
-			Args:    smithery.ParsedCommand.Args,
-			Env:     smithery.ParsedCommand.Env,
+			Command:          smithery.ParsedCommand.Command,
+			Args:             smithery.ParsedCommand.Args,
+			Env:              smithery.ParsedCommand.Env,
+			SuperGatewayArgs: superGatewayArgs,
 		},
 		Enterprise:    hub.Enterprise,
 		ComingSoon:    hub.ComingSoon,

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -1,0 +1,49 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/blaxel-ai/mcp-hub/internal/hub"
+	"github.com/blaxel-ai/mcp-hub/internal/smithery"
+)
+
+func TestCatalogLoadHTTPUpstream(t *testing.T) {
+	repo := &hub.Repository{
+		DisplayName:     "Dummy MCP",
+		Icon:            "icon",
+		Description:     "description",
+		LongDescription: "long description",
+		HTTPUpstream:    &hub.HTTPUpstream{URL: "http://127.0.0.1:8081/mcp"},
+	}
+	cfg := &smithery.SmitheryConfig{
+		ParsedCommand: &smithery.Command{
+			Command: "go",
+			Args:    []string{"run", "./cmd/dummy_mcp"},
+			Env:     map[string]string{},
+		},
+		StartCommand: smithery.StartCommand{
+			ConfigSchema: smithery.ConfigSchema{Properties: map[string]smithery.Property{}},
+		},
+	}
+
+	catalog := &Catalog{}
+	if err := catalog.Load("dummy", repo, "ghcr.io/blaxel-ai/hub/dummy:latest", cfg); err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(catalog.Artifacts) != 1 {
+		t.Fatalf("len(Artifacts) = %d, want 1", len(catalog.Artifacts))
+	}
+	artifact := catalog.Artifacts[0]
+	if artifact.Transport != "http-stream" {
+		t.Fatalf("Transport = %q, want http-stream", artifact.Transport)
+	}
+	wantArgs := []string{"--port", "80", "--transport", "http-stream", "--http-upstream", "http://127.0.0.1:8081/mcp", "--http-upstream-path", "/mcp", "--stdio"}
+	if len(artifact.Entrypoint.SuperGatewayArgs) != len(wantArgs) {
+		t.Fatalf("len(SuperGatewayArgs) = %d, want %d (%v)", len(artifact.Entrypoint.SuperGatewayArgs), len(wantArgs), artifact.Entrypoint.SuperGatewayArgs)
+	}
+	for i := range wantArgs {
+		if artifact.Entrypoint.SuperGatewayArgs[i] != wantArgs[i] {
+			t.Fatalf("SuperGatewayArgs[%d] = %q, want %q (all args: %v)", i, artifact.Entrypoint.SuperGatewayArgs[i], wantArgs[i], artifact.Entrypoint.SuperGatewayArgs)
+		}
+	}
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -3,6 +3,8 @@ package hub
 import (
 	"errors"
 	"fmt"
+	"net"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -45,14 +47,86 @@ type Repository struct {
 	Secrets         []string                 `yaml:"secrets" mandatory:"false"`
 	HiddenSecrets   []string                 `yaml:"hiddenSecrets" mandatory:"false"`
 	OAuth           *OAuth                   `yaml:"oauth" mandatory:"false"`
+	HTTPUpstream    *HTTPUpstream            `yaml:"httpUpstream" mandatory:"false"`
 	Integration     string                   `yaml:"integration" mandatory:"false"`
 	Tags            []string                 `yaml:"tags"`
 	Categories      []string                 `yaml:"categories"`
 }
 
+type HTTPUpstream struct {
+	URL         string `yaml:"url"`
+	AllowedPath string `yaml:"allowedPath"`
+}
+
 type OAuth struct {
 	Type   string   `yaml:"type"`
 	Scopes []string `yaml:"scopes"`
+}
+
+func (h *HTTPUpstream) ValidateWithDefaultValues() error {
+	upstreamURL, err := h.parsedURL()
+	if err != nil {
+		return err
+	}
+	if h.AllowedPath == "" {
+		h.AllowedPath = upstreamURL.Path
+		if h.AllowedPath == "" {
+			h.AllowedPath = "/mcp"
+		}
+	}
+	if !strings.HasPrefix(h.AllowedPath, "/") {
+		return fmt.Errorf("httpUpstream.allowedPath must start with /")
+	}
+	if h.AllowedPath == "/" {
+		return fmt.Errorf("httpUpstream.allowedPath must not be /")
+	}
+	if strings.Contains(h.AllowedPath, "://") {
+		return fmt.Errorf("httpUpstream.allowedPath must be a path, not a URL")
+	}
+	return nil
+}
+
+func (h *HTTPUpstream) SuperGatewayArgs() ([]string, error) {
+	if h == nil {
+		return nil, nil
+	}
+	if err := h.ValidateWithDefaultValues(); err != nil {
+		return nil, err
+	}
+	return []string{
+		"--port", "80",
+		"--transport", "http-stream",
+		"--http-upstream", h.URL,
+		"--http-upstream-path", h.AllowedPath,
+		"--stdio",
+	}, nil
+}
+
+func (h *HTTPUpstream) parsedURL() (*neturl.URL, error) {
+	if h.URL == "" {
+		return nil, fmt.Errorf("httpUpstream.url is required")
+	}
+	upstreamURL, err := neturl.Parse(h.URL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid httpUpstream.url: %w", err)
+	}
+	if upstreamURL.Scheme != "http" {
+		return nil, fmt.Errorf("httpUpstream.url must use http scheme")
+	}
+	if upstreamURL.User != nil {
+		return nil, fmt.Errorf("httpUpstream.url must not include userinfo")
+	}
+	host := upstreamURL.Hostname()
+	if host == "" {
+		return nil, fmt.Errorf("httpUpstream.url must include a host")
+	}
+	if host != "localhost" {
+		ip := net.ParseIP(host)
+		if ip == nil || !ip.IsLoopback() {
+			return nil, fmt.Errorf("httpUpstream.url host must be loopback")
+		}
+	}
+	return upstreamURL, nil
 }
 
 func (h *Hub) Read(path string) error {
@@ -117,6 +191,15 @@ func (h *Hub) ValidateWithDefaultValues() error {
 				case reflect.Bool:
 					value.SetBool(defaultVal == "true")
 				}
+			}
+		}
+
+		if repository.HTTPUpstream != nil {
+			if err := repository.HTTPUpstream.ValidateWithDefaultValues(); err != nil {
+				errs = append(errs, fmt.Errorf("repository %s: %w", name, err))
+			}
+			if repository.Transport == "" {
+				repository.Transport = "http-stream"
 			}
 		}
 	}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -80,8 +80,8 @@ func (h *HTTPUpstream) ValidateWithDefaultValues() error {
 	if h.AllowedPath == "/" {
 		return fmt.Errorf("httpUpstream.allowedPath must not be /")
 	}
-	if strings.Contains(h.AllowedPath, "://") {
-		return fmt.Errorf("httpUpstream.allowedPath must be a path, not a URL")
+	if strings.Contains(h.AllowedPath, "://") || strings.ContainsAny(h.AllowedPath, "?#") {
+		return fmt.Errorf("httpUpstream.allowedPath must be a path without query or fragment")
 	}
 	return nil
 }
@@ -115,6 +115,9 @@ func (h *HTTPUpstream) parsedURL() (*neturl.URL, error) {
 	}
 	if upstreamURL.User != nil {
 		return nil, fmt.Errorf("httpUpstream.url must not include userinfo")
+	}
+	if upstreamURL.RawQuery != "" || upstreamURL.Fragment != "" {
+		return nil, fmt.Errorf("httpUpstream.url must not include query or fragment")
 	}
 	host := upstreamURL.Hostname()
 	if host == "" {

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -39,11 +39,34 @@ func TestHTTPUpstreamValidateWithDefaultValues(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects query and fragment", func(t *testing.T) {
+		for _, rawURL := range []string{
+			"http://127.0.0.1:8081/mcp?token=secret",
+			"http://127.0.0.1:8081/mcp#secret",
+		} {
+			upstream := &HTTPUpstream{URL: rawURL}
+			err := upstream.ValidateWithDefaultValues()
+			if err == nil || !strings.Contains(err.Error(), "query or fragment") {
+				t.Fatalf("%s: expected query or fragment error, got %v", rawURL, err)
+			}
+		}
+	})
+
 	t.Run("rejects root allowed path", func(t *testing.T) {
 		upstream := &HTTPUpstream{URL: "http://127.0.0.1:8081/mcp", AllowedPath: "/"}
 		err := upstream.ValidateWithDefaultValues()
 		if err == nil || !strings.Contains(err.Error(), "must not be /") {
 			t.Fatalf("expected root path error, got %v", err)
+		}
+	})
+
+	t.Run("rejects allowed path query and fragment", func(t *testing.T) {
+		for _, allowedPath := range []string{"/mcp?token=secret", "/mcp#secret"} {
+			upstream := &HTTPUpstream{URL: "http://127.0.0.1:8081/mcp", AllowedPath: allowedPath}
+			err := upstream.ValidateWithDefaultValues()
+			if err == nil || !strings.Contains(err.Error(), "query or fragment") {
+				t.Fatalf("%s: expected query or fragment error, got %v", allowedPath, err)
+			}
 		}
 	})
 }

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -1,0 +1,84 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHTTPUpstreamValidateWithDefaultValues(t *testing.T) {
+	t.Run("defaults allowed path from URL", func(t *testing.T) {
+		upstream := &HTTPUpstream{URL: "http://127.0.0.1:8081/mcp"}
+		if err := upstream.ValidateWithDefaultValues(); err != nil {
+			t.Fatalf("ValidateWithDefaultValues returned error: %v", err)
+		}
+		if upstream.AllowedPath != "/mcp" {
+			t.Fatalf("AllowedPath = %q, want /mcp", upstream.AllowedPath)
+		}
+	})
+
+	t.Run("rejects non loopback host", func(t *testing.T) {
+		for _, rawURL := range []string{
+			"http://example.com/mcp",
+			"http://169.254.169.254/mcp",
+			"http://127.0.0.1.evil.test/mcp",
+			"http://localhost.evil.test/mcp",
+		} {
+			upstream := &HTTPUpstream{URL: rawURL}
+			err := upstream.ValidateWithDefaultValues()
+			if err == nil || !strings.Contains(err.Error(), "loopback") {
+				t.Fatalf("%s: expected loopback error, got %v", rawURL, err)
+			}
+		}
+	})
+
+	t.Run("rejects userinfo", func(t *testing.T) {
+		upstream := &HTTPUpstream{URL: "http://token@127.0.0.1:8081/mcp"}
+		err := upstream.ValidateWithDefaultValues()
+		if err == nil || !strings.Contains(err.Error(), "userinfo") {
+			t.Fatalf("expected userinfo error, got %v", err)
+		}
+	})
+
+	t.Run("rejects root allowed path", func(t *testing.T) {
+		upstream := &HTTPUpstream{URL: "http://127.0.0.1:8081/mcp", AllowedPath: "/"}
+		err := upstream.ValidateWithDefaultValues()
+		if err == nil || !strings.Contains(err.Error(), "must not be /") {
+			t.Fatalf("expected root path error, got %v", err)
+		}
+	})
+}
+
+func TestHTTPUpstreamSuperGatewayArgs(t *testing.T) {
+	upstream := &HTTPUpstream{URL: "http://localhost:8081/mcp"}
+	args, err := upstream.SuperGatewayArgs()
+	if err != nil {
+		t.Fatalf("SuperGatewayArgs returned error: %v", err)
+	}
+	want := []string{"--port", "80", "--transport", "http-stream", "--http-upstream", "http://localhost:8081/mcp", "--http-upstream-path", "/mcp", "--stdio"}
+	if len(args) != len(want) {
+		t.Fatalf("len(args) = %d, want %d (%v)", len(args), len(want), args)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q (all args: %v)", i, args[i], want[i], args)
+		}
+	}
+}
+
+func TestHubValidateHTTPUpstreamDefaultsTransport(t *testing.T) {
+	h := &Hub{Repositories: map[string]*Repository{
+		"dummy": {
+			DisplayName:     "Dummy",
+			Icon:            "icon",
+			Description:     "description",
+			LongDescription: "long description",
+			HTTPUpstream:    &HTTPUpstream{URL: "http://127.0.0.1:8081/mcp"},
+		},
+	}}
+	if err := h.ValidateWithDefaultValues(); err != nil {
+		t.Fatalf("ValidateWithDefaultValues returned error: %v", err)
+	}
+	if got := h.Repositories["dummy"].Transport; got != "http-stream" {
+		t.Fatalf("Transport = %q, want http-stream", got)
+	}
+}

--- a/internal/smithery/smithery_config.go
+++ b/internal/smithery/smithery_config.go
@@ -27,8 +27,16 @@ type Command struct {
 	Env     map[string]string `json:"env"`
 }
 
-func (c *Command) Entrypoint() string {
-	entrypoint := []string{"\"./super-gateway\"", "\"--transport\"", "\"http-stream\"", "\"--port\"", "\"80\"", "\"--stdio\""}
+func (c *Command) Entrypoint(superGatewayArgs ...[]string) string {
+	args := []string{"--transport", "http-stream", "--port", "80", "--stdio"}
+	if len(superGatewayArgs) > 0 && len(superGatewayArgs[0]) > 0 {
+		args = superGatewayArgs[0]
+	}
+
+	entrypoint := []string{"\"./super-gateway\""}
+	for _, arg := range args {
+		entrypoint = append(entrypoint, fmt.Sprintf("%q", arg))
+	}
 	return strings.Join(entrypoint, ",")
 }
 

--- a/internal/smithery/smithery_config_test.go
+++ b/internal/smithery/smithery_config_test.go
@@ -1,0 +1,21 @@
+package smithery
+
+import "testing"
+
+func TestCommandEntrypointUsesCustomSuperGatewayArgs(t *testing.T) {
+	cmd := &Command{}
+	entrypoint := cmd.Entrypoint([]string{"--port", "80", "--transport", "http-stream", "--http-upstream", "http://127.0.0.1:8081/mcp", "--http-upstream-path", "/mcp", "--stdio"})
+	want := `"./super-gateway","--port","80","--transport","http-stream","--http-upstream","http://127.0.0.1:8081/mcp","--http-upstream-path","/mcp","--stdio"`
+	if entrypoint != want {
+		t.Fatalf("entrypoint = %s, want %s", entrypoint, want)
+	}
+}
+
+func TestCommandEntrypointDefaultPreservesStdioMode(t *testing.T) {
+	cmd := &Command{}
+	entrypoint := cmd.Entrypoint()
+	want := `"./super-gateway","--transport","http-stream","--port","80","--stdio"`
+	if entrypoint != want {
+		t.Fatalf("entrypoint = %s, want %s", entrypoint, want)
+	}
+}

--- a/super-gateway/main.go
+++ b/super-gateway/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"bufio"
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -119,6 +122,84 @@ func rewriteOAuthURL(line string) string {
 type Session struct {
 	ProtocolVersion string
 	CreatedAt       time.Time
+}
+
+type HTTPUpstreamConfig struct {
+	URL        *url.URL
+	PublicPath string
+}
+
+func ParseHTTPUpstreamConfig(rawURL, publicPath string) (*HTTPUpstreamConfig, error) {
+	if rawURL == "" {
+		return nil, nil
+	}
+	upstreamURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid http upstream URL: %w", err)
+	}
+	if upstreamURL.Scheme != "http" {
+		return nil, fmt.Errorf("http upstream URL must use http scheme")
+	}
+	if upstreamURL.User != nil {
+		return nil, fmt.Errorf("http upstream URL must not include userinfo")
+	}
+	host := upstreamURL.Hostname()
+	if host == "" {
+		return nil, fmt.Errorf("http upstream URL must include a host")
+	}
+	if host != "localhost" {
+		ip := net.ParseIP(host)
+		if ip == nil || !ip.IsLoopback() {
+			return nil, fmt.Errorf("http upstream host must be loopback")
+		}
+	}
+	if upstreamURL.Path == "" {
+		upstreamURL.Path = "/mcp"
+	}
+	if publicPath == "" {
+		publicPath = upstreamURL.Path
+	}
+	if !strings.HasPrefix(publicPath, "/") || strings.Contains(publicPath, "://") || publicPath == "/" {
+		return nil, fmt.Errorf("http upstream public path must be a non-root path starting with /")
+	}
+	return &HTTPUpstreamConfig{URL: upstreamURL, PublicPath: publicPath}, nil
+}
+
+func newLoopbackHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{Transport: newLoopbackHTTPTransport(), Timeout: timeout}
+}
+
+func newLoopbackHTTPTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = dialLoopbackOnly
+	return transport
+}
+
+func dialLoopbackOnly(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+
+	dialer := &net.Dialer{}
+	if ip := net.ParseIP(host); ip != nil {
+		if !ip.IsLoopback() {
+			return nil, fmt.Errorf("refusing to dial non-loopback upstream host %s", host)
+		}
+		return dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+	}
+
+	addresses, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	for _, address := range addresses {
+		if address.IP.IsLoopback() {
+			return dialer.DialContext(ctx, network, net.JoinHostPort(address.IP.String(), port))
+		}
+	}
+	return nil, fmt.Errorf("refusing to dial non-loopback upstream host %s", host)
 }
 
 func NewGateway() *Gateway {
@@ -515,6 +596,59 @@ func (g *Gateway) WaitForReady(timeout time.Duration) error {
 	}
 }
 
+func (g *Gateway) WaitForHTTPUpstreamReady(upstream *url.URL, timeout time.Duration) error {
+	log.Printf("Waiting for HTTP upstream MCP server to be ready (timeout: %v)...", timeout)
+
+	readinessMsg := JSONRPCMessage{
+		JSONRPC: "2.0",
+		ID:      "readiness-check",
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"super-gateway","version":"1.0.0"}}`),
+	}
+	data, err := json.Marshal(readinessMsg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal readiness check message: %w", err)
+	}
+
+	client := newLoopbackHTTPClient(5 * time.Second)
+	retryTicker := time.NewTicker(1 * time.Second)
+	defer retryTicker.Stop()
+	timeoutTimer := time.NewTimer(timeout)
+	defer timeoutTimer.Stop()
+
+	attempt := 0
+	for {
+		attempt++
+		request, err := http.NewRequest(http.MethodPost, upstream.String(), bytes.NewReader(data)) // #nosec G704 -- ParseHTTPUpstreamConfig and newLoopbackHTTPTransport enforce loopback-only HTTP with no proxy.
+		if err != nil {
+			return fmt.Errorf("failed to create readiness request: %w", err)
+		}
+		request.Header.Set("Content-Type", "application/json")
+		request.Header.Set("Accept", "application/json, text/event-stream")
+		request.Header.Set("MCP-Protocol-Version", "2024-11-05")
+
+		response, err := client.Do(request) // #nosec G704 -- request uses a loopback-only URL and transport refuses non-loopback dials.
+		if err == nil {
+			_, _ = io.Copy(io.Discard, response.Body)
+			_ = response.Body.Close()
+			if response.StatusCode >= 200 && response.StatusCode < 300 {
+				log.Printf("HTTP upstream MCP server is ready after %d attempt(s)", attempt)
+				return nil
+			}
+			log.Printf("HTTP upstream readiness attempt %d returned non-2xx status", attempt)
+		} else {
+			log.Printf("HTTP upstream readiness attempt %d failed: %v", attempt, err)
+		}
+
+		select {
+		case <-retryTicker.C:
+			continue
+		case <-timeoutTimer.C:
+			return fmt.Errorf("timeout waiting for HTTP upstream MCP server to be ready after %d attempt(s)", attempt)
+		}
+	}
+}
+
 // Run starts the gateway's main loop
 func (g *Gateway) Run() {
 	for {
@@ -786,6 +920,74 @@ func (g *Gateway) HandleHTTPMessage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (g *Gateway) HandleHTTPUpstream(config *HTTPUpstreamConfig) http.Handler {
+	proxy := &httputil.ReverseProxy{
+		Transport: newLoopbackHTTPTransport(),
+		Rewrite: func(proxyRequest *httputil.ProxyRequest) {
+			proxyRequest.SetURL(config.URL)
+			proxyRequest.Out.URL.Path = config.URL.Path
+			proxyRequest.Out.URL.RawPath = config.URL.RawPath
+			proxyRequest.Out.URL.RawQuery = joinRawQuery(config.URL.RawQuery, proxyRequest.In.URL.RawQuery)
+			proxyRequest.Out.Host = config.URL.Host
+			stripPrivateRequestHeaders(proxyRequest.Out.Header)
+		},
+		ModifyResponse: func(response *http.Response) error {
+			stripPrivateResponseHeaders(response.Header)
+			return nil
+		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
+			log.Printf("HTTP upstream proxy error")
+			http.Error(w, "HTTP upstream unavailable", http.StatusBadGateway)
+		},
+		FlushInterval: -1,
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != config.PublicPath {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		proxy.ServeHTTP(w, r)
+	})
+}
+
+func joinRawQuery(fixedQuery, incomingQuery string) string {
+	if fixedQuery == "" {
+		return incomingQuery
+	}
+	if incomingQuery == "" {
+		return fixedQuery
+	}
+	return fixedQuery + "&" + incomingQuery
+}
+
+func stripPrivateRequestHeaders(headers http.Header) {
+	stripPrivateHeaders(headers, []string{"Authorization", "Cookie", "Proxy-Authorization"})
+}
+
+func stripPrivateResponseHeaders(headers http.Header) {
+	stripPrivateHeaders(headers, []string{"Set-Cookie"})
+}
+
+func stripPrivateHeaders(headers http.Header, names []string) {
+	for _, header := range append([]string{
+		"Forwarded",
+		"X-Real-Ip",
+	}, names...) {
+		headers.Del(header)
+	}
+	for header := range headers {
+		canonical := http.CanonicalHeaderKey(header)
+		if strings.HasPrefix(canonical, "X-Forwarded-") || strings.HasPrefix(canonical, "X-Blaxel-") || strings.HasPrefix(canonical, "Cf-") {
+			headers.Del(header)
+		}
+	}
+}
+
 // readPump reads messages from the WebSocket connection
 func (c *Client) readPump(g *Gateway) {
 	defer func() {
@@ -842,10 +1044,12 @@ func (g *Gateway) HandleHealth(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	var (
-		stdioCmd       []string
-		port           int
-		transport      string
-		authentication bool
+		stdioCmd         []string
+		port             int
+		transport        string
+		authentication   bool
+		httpUpstreamRaw  string
+		httpUpstreamPath string
 	)
 
 	// Show help if no arguments
@@ -855,6 +1059,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  --port <port>         Port to listen on (default: 8000)\n")
 		fmt.Fprintf(os.Stderr, "  --transport <transport> Connection transport: 'websocket' or 'http-stream' (default: websocket)\n")
 		fmt.Fprintf(os.Stderr, "  --authentication      Enable OAuth callback proxy (forwards non-MCP requests to port 12849)\n")
+		fmt.Fprintf(os.Stderr, "  --http-upstream <url> Fixed loopback HTTP MCP upstream URL to proxy instead of stdio JSON-RPC\n")
+		fmt.Fprintf(os.Stderr, "  --http-upstream-path <path> Public MCP path to allow for HTTP upstream mode (default: upstream path)\n")
 		fmt.Fprintf(os.Stderr, "  --stdio <command>     MCP server command to run\n")
 		fmt.Fprintf(os.Stderr, "\nExamples:\n")
 		fmt.Fprintf(os.Stderr, "  WebSocket transport:\n")
@@ -863,6 +1069,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "    %s --port 8000 --transport http-stream --stdio npx -y @modelcontextprotocol/server-filesystem /path\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  With OAuth authentication (mcp-remote):\n")
 		fmt.Fprintf(os.Stderr, "    %s --port 8000 --transport http-stream --authentication --stdio mcp-remote https://example.com/mcp\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  Existing HTTP MCP upstream on loopback:\n")
+		fmt.Fprintf(os.Stderr, "    %s --port 8000 --transport http-stream --http-upstream http://127.0.0.1:8081/mcp --stdio go run ./cmd/dummy_mcp\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "\nNote: Everything after --stdio is passed to the subprocess\n")
 		os.Exit(1)
 	}
@@ -893,6 +1101,22 @@ func main() {
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--authentication" {
 			authentication = true
+			break
+		}
+	}
+
+	// Find --http-upstream flag if present
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--http-upstream" && i+1 < len(args) {
+			httpUpstreamRaw = args[i+1]
+			break
+		}
+	}
+
+	// Find --http-upstream-path flag if present
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--http-upstream-path" && i+1 < len(args) {
+			httpUpstreamPath = args[i+1]
 			break
 		}
 	}
@@ -932,6 +1156,17 @@ func main() {
 	// Everything after --stdio is the command and its arguments
 	stdioCmd = args[stdioIndex+1:]
 
+	httpUpstreamConfig, err := ParseHTTPUpstreamConfig(httpUpstreamRaw, httpUpstreamPath)
+	if err != nil {
+		log.Fatalf("Invalid HTTP upstream config: %v", err)
+	}
+	if httpUpstreamConfig != nil && transport != "http-stream" {
+		log.Fatal("--http-upstream requires --transport http-stream")
+	}
+	if httpUpstreamConfig != nil && authentication {
+		log.Fatal("--http-upstream cannot be combined with --authentication")
+	}
+
 	gateway := NewGateway()
 
 	// Start the MCP server
@@ -942,7 +1177,13 @@ func main() {
 	// Wait for MCP server to be ready (30 second timeout)
 	// Skip readiness check if SKIP_READINESS_CHECK env var is set
 	if os.Getenv("SKIP_READINESS_CHECK") != "true" {
-		if err := gateway.WaitForReady(30 * time.Second); err != nil {
+		var err error
+		if httpUpstreamConfig != nil {
+			err = gateway.WaitForHTTPUpstreamReady(httpUpstreamConfig.URL, 30*time.Second)
+		} else {
+			err = gateway.WaitForReady(30 * time.Second)
+		}
+		if err != nil {
 			log.Printf("Warning: MCP server readiness check failed: %v", err)
 			log.Printf("Continuing anyway - server may not be fully initialized")
 			// Don't fail, just warn - some servers have issues with stdio responses
@@ -995,27 +1236,37 @@ func main() {
 		})
 	} else {
 		log.Printf("HTTP streaming endpoints:")
-		log.Printf("  - MCP endpoint: POST http://localhost:%d/mcp", port)
 
 		mux := http.NewServeMux()
-		mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
-			accept := r.Header.Get("Accept")
-			// Require Accept to indicate support (also accept wildcard */* and empty Accept)
-			if accept != "" && !strings.Contains(accept, "application/json") && !strings.Contains(accept, "text/event-stream") && !strings.Contains(accept, "*/*") && r.Method == http.MethodPost {
-				http.Error(w, "Unsupported Accept header", http.StatusNotAcceptable)
-				return
-			}
+		if httpUpstreamConfig != nil {
+			log.Printf("  - MCP endpoint: configured HTTP upstream path")
+			mux.Handle(httpUpstreamConfig.PublicPath, gateway.HandleHTTPUpstream(httpUpstreamConfig))
+		} else {
+			log.Printf("  - MCP endpoint: POST http://localhost:%d/mcp", port)
+			mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+				accept := r.Header.Get("Accept")
+				// Require Accept to indicate support (also accept wildcard */* and empty Accept)
+				if accept != "" && !strings.Contains(accept, "application/json") && !strings.Contains(accept, "text/event-stream") && !strings.Contains(accept, "*/*") && r.Method == http.MethodPost {
+					http.Error(w, "Unsupported Accept header", http.StatusNotAcceptable)
+					return
+				}
 
-			if r.Method == http.MethodGet {
+				if r.Method == http.MethodGet {
+					http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+					return
+				}
+				if r.Method == http.MethodPost {
+					gateway.HandleHTTPMessage(w, r)
+					return
+				}
 				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-				return
-			}
-			if r.Method == http.MethodPost {
-				gateway.HandleHTTPMessage(w, r)
-				return
-			}
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		})
+			})
+		}
+
+		mcpEndpoint := "/mcp"
+		if httpUpstreamConfig != nil {
+			mcpEndpoint = httpUpstreamConfig.PublicPath
+		}
 
 		// Set up OAuth proxy if authentication flag is enabled
 		if authentication {
@@ -1040,7 +1291,7 @@ func main() {
 					w.Header().Set("Content-Type", "application/json")
 					json.NewEncoder(w).Encode(map[string]interface{}{
 						"transport": "http-stream",
-						"endpoint":  "/mcp",
+						"endpoint":  mcpEndpoint,
 					})
 					return
 				}
@@ -1059,7 +1310,7 @@ func main() {
 				w.Header().Set("Content-Type", "application/json")
 				json.NewEncoder(w).Encode(map[string]interface{}{
 					"transport": "http-stream",
-					"endpoint":  "/mcp",
+					"endpoint":  mcpEndpoint,
 				})
 			})
 		}

--- a/super-gateway/main.go
+++ b/super-gateway/main.go
@@ -143,6 +143,9 @@ func ParseHTTPUpstreamConfig(rawURL, publicPath string) (*HTTPUpstreamConfig, er
 	if upstreamURL.User != nil {
 		return nil, fmt.Errorf("http upstream URL must not include userinfo")
 	}
+	if upstreamURL.RawQuery != "" || upstreamURL.Fragment != "" {
+		return nil, fmt.Errorf("http upstream URL must not include query or fragment")
+	}
 	host := upstreamURL.Hostname()
 	if host == "" {
 		return nil, fmt.Errorf("http upstream URL must include a host")
@@ -159,8 +162,8 @@ func ParseHTTPUpstreamConfig(rawURL, publicPath string) (*HTTPUpstreamConfig, er
 	if publicPath == "" {
 		publicPath = upstreamURL.Path
 	}
-	if !strings.HasPrefix(publicPath, "/") || strings.Contains(publicPath, "://") || publicPath == "/" {
-		return nil, fmt.Errorf("http upstream public path must be a non-root path starting with /")
+	if !strings.HasPrefix(publicPath, "/") || strings.Contains(publicPath, "://") || strings.ContainsAny(publicPath, "?#") || publicPath == "/" {
+		return nil, fmt.Errorf("http upstream public path must be a non-root path starting with / and must not include query or fragment")
 	}
 	return &HTTPUpstreamConfig{URL: upstreamURL, PublicPath: publicPath}, nil
 }
@@ -935,8 +938,8 @@ func (g *Gateway) HandleHTTPUpstream(config *HTTPUpstreamConfig) http.Handler {
 			stripPrivateResponseHeaders(response.Header)
 			return nil
 		},
-		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
-			log.Printf("HTTP upstream proxy error")
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			log.Printf("HTTP upstream proxy error: %v", err)
 			http.Error(w, "HTTP upstream unavailable", http.StatusBadGateway)
 		},
 		FlushInterval: -1,

--- a/super-gateway/main_test.go
+++ b/super-gateway/main_test.go
@@ -51,10 +51,31 @@ func TestParseHTTPUpstreamConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects query and fragment", func(t *testing.T) {
+		for _, rawURL := range []string{
+			"http://127.0.0.1:8081/mcp?token=secret",
+			"http://127.0.0.1:8081/mcp#secret",
+		} {
+			_, err := ParseHTTPUpstreamConfig(rawURL, "")
+			if err == nil || !strings.Contains(err.Error(), "query or fragment") {
+				t.Fatalf("%s: expected query or fragment error, got %v", rawURL, err)
+			}
+		}
+	})
+
 	t.Run("rejects root public path", func(t *testing.T) {
 		_, err := ParseHTTPUpstreamConfig("http://127.0.0.1:8081/mcp", "/")
 		if err == nil || !strings.Contains(err.Error(), "non-root") {
 			t.Fatalf("expected non-root path error, got %v", err)
+		}
+	})
+
+	t.Run("rejects public path query and fragment", func(t *testing.T) {
+		for _, publicPath := range []string{"/mcp?token=secret", "/mcp#secret"} {
+			_, err := ParseHTTPUpstreamConfig("http://127.0.0.1:8081/mcp", publicPath)
+			if err == nil || !strings.Contains(err.Error(), "query or fragment") {
+				t.Fatalf("%s: expected query or fragment error, got %v", publicPath, err)
+			}
 		}
 	})
 

--- a/super-gateway/main_test.go
+++ b/super-gateway/main_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseHTTPUpstreamConfig(t *testing.T) {
+	t.Run("defaults public path from upstream URL", func(t *testing.T) {
+		config, err := ParseHTTPUpstreamConfig("http://127.0.0.1:8081/mcp", "")
+		if err != nil {
+			t.Fatalf("ParseHTTPUpstreamConfig returned error: %v", err)
+		}
+		if config.PublicPath != "/mcp" {
+			t.Fatalf("PublicPath = %q, want /mcp", config.PublicPath)
+		}
+	})
+
+	t.Run("rejects non loopback hosts", func(t *testing.T) {
+		for _, rawURL := range []string{
+			"http://example.com/mcp",
+			"http://169.254.169.254/mcp",
+			"http://127.0.0.1.evil.test/mcp",
+			"http://localhost.evil.test/mcp",
+		} {
+			_, err := ParseHTTPUpstreamConfig(rawURL, "")
+			if err == nil || !strings.Contains(err.Error(), "loopback") {
+				t.Fatalf("%s: expected loopback error, got %v", rawURL, err)
+			}
+		}
+	})
+
+	t.Run("accepts IPv6 loopback", func(t *testing.T) {
+		config, err := ParseHTTPUpstreamConfig("http://[::1]:8081/mcp", "")
+		if err != nil {
+			t.Fatalf("ParseHTTPUpstreamConfig returned error: %v", err)
+		}
+		if config.URL.Hostname() != "::1" {
+			t.Fatalf("hostname = %q, want ::1", config.URL.Hostname())
+		}
+	})
+
+	t.Run("rejects userinfo", func(t *testing.T) {
+		_, err := ParseHTTPUpstreamConfig("http://token@127.0.0.1:8081/mcp", "")
+		if err == nil || !strings.Contains(err.Error(), "userinfo") {
+			t.Fatalf("expected userinfo error, got %v", err)
+		}
+	})
+
+	t.Run("rejects root public path", func(t *testing.T) {
+		_, err := ParseHTTPUpstreamConfig("http://127.0.0.1:8081/mcp", "/")
+		if err == nil || !strings.Contains(err.Error(), "non-root") {
+			t.Fatalf("expected non-root path error, got %v", err)
+		}
+	})
+
+	t.Run("rejects https scheme", func(t *testing.T) {
+		_, err := ParseHTTPUpstreamConfig("https://127.0.0.1:8081/mcp", "")
+		if err == nil || !strings.Contains(err.Error(), "http scheme") {
+			t.Fatalf("expected http scheme error, got %v", err)
+		}
+	})
+}
+
+func TestHTTPUpstreamProxy(t *testing.T) {
+	upstreamCalled := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+		if r.URL.Path != "/upstream-mcp" {
+			t.Fatalf("upstream path = %q, want /upstream-mcp", r.URL.Path)
+		}
+		if r.URL.RawQuery != "clientId=abc" {
+			t.Fatalf("upstream query = %q, want clientId=abc", r.URL.RawQuery)
+		}
+		for _, header := range []string{"Authorization", "Cookie", "Forwarded", "Proxy-Authorization", "X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto", "X-Real-Ip", "X-Blaxel-Workspace", "Cf-Connecting-Ip"} {
+			if got := r.Header.Get(header); got != "" {
+				t.Fatalf("%s was forwarded as %q", header, got)
+			}
+		}
+		if got := r.Header.Get("Mcp-Session-Id"); got != "session-1" {
+			t.Fatalf("Mcp-Session-Id = %q, want session-1", got)
+		}
+		if got := r.Header.Get("MCP-Protocol-Version"); got != "2024-11-05" {
+			t.Fatalf("MCP-Protocol-Version = %q, want 2024-11-05", got)
+		}
+		w.Header().Set("Mcp-Session-Id", "upstream-session")
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Set-Cookie", "private=true")
+		w.Header().Set("X-Blaxel-Region", "private")
+		w.Header().Set("Cf-Ray", "private")
+		w.Header().Set("X-Forwarded-Host", "private")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	defer upstream.Close()
+
+	config, err := ParseHTTPUpstreamConfig(upstream.URL+"/upstream-mcp", "/mcp")
+	if err != nil {
+		t.Fatalf("ParseHTTPUpstreamConfig returned error: %v", err)
+	}
+	handler := NewGateway().HandleHTTPUpstream(config)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp?clientId=abc", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Cookie", "private=true")
+	req.Header.Set("Forwarded", "for=203.0.113.1")
+	req.Header.Set("Proxy-Authorization", "Basic private")
+	req.Header.Set("X-Forwarded-For", "203.0.113.1")
+	req.Header.Set("X-Forwarded-Host", "external.example")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Real-Ip", "203.0.113.1")
+	req.Header.Set("X-Blaxel-Workspace", "workspace")
+	req.Header.Set("Cf-Connecting-Ip", "203.0.113.1")
+	req.Header.Set("Mcp-Session-Id", "session-1")
+	req.Header.Set("MCP-Protocol-Version", "2024-11-05")
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	response := recorder.Result()
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+
+	if !upstreamCalled {
+		t.Fatal("upstream was not called")
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.StatusCode, string(body))
+	}
+	if got := response.Header.Get("Mcp-Session-Id"); got != "upstream-session" {
+		t.Fatalf("response Mcp-Session-Id = %q, want upstream-session", got)
+	}
+	for _, header := range []string{"Set-Cookie", "X-Blaxel-Region", "Cf-Ray", "X-Forwarded-Host"} {
+		if got := response.Header.Get(header); got != "" {
+			t.Fatalf("response %s was forwarded as %q", header, got)
+		}
+	}
+	if !strings.Contains(string(body), `"jsonrpc":"2.0"`) {
+		t.Fatalf("unexpected body: %s", string(body))
+	}
+}
+
+func TestHTTPUpstreamProxyRejectsOtherPathsAndMethods(t *testing.T) {
+	upstreamCalled := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+	}))
+	defer upstream.Close()
+
+	config, err := ParseHTTPUpstreamConfig(upstream.URL+"/mcp", "/mcp")
+	if err != nil {
+		t.Fatalf("ParseHTTPUpstreamConfig returned error: %v", err)
+	}
+	handler := NewGateway().HandleHTTPUpstream(config)
+
+	for _, path := range []string{"/not-mcp", "/mcp/extra", "/mcp2"} {
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, path, strings.NewReader("{}")))
+
+		if recorder.Code != http.StatusNotFound {
+			t.Fatalf("%s status = %d, want 404", path, recorder.Code)
+		}
+	}
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/mcp", nil))
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET /mcp status = %d, want 405", recorder.Code)
+	}
+
+	if upstreamCalled {
+		t.Fatal("upstream should not be called for non-MCP paths or methods")
+	}
+}
+
+func TestDialLoopbackOnlyRejectsNonLoopback(t *testing.T) {
+	_, err := dialLoopbackOnly(context.Background(), "tcp", "169.254.169.254:80")
+	if err == nil || !strings.Contains(err.Error(), "non-loopback") {
+		t.Fatalf("expected non-loopback error, got %v", err)
+	}
+}


### PR DESCRIPTION
**What this is:** support for importing existing loopback HTTP MCP servers without patching the upstream app for Blaxel-specific hosting.

**What it changes:**
- adds `httpUpstream` hub config that runs the original server and proxies only the configured MCP path through `super-gateway`
- constrains the proxy to loopback HTTP, strips private forwarding/auth headers, and keeps non-MCP paths closed
- carries the HTTP-upstream entrypoint through catalog generation

Checked locally with Go tests/vet, server build, TypeScript server build, import smoke test, and a local HTTP-upstream tools/list + tools/call flow.

Linear: ENG-2853

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Follow-up commit rejects query strings and fragments in HTTP upstream URLs and allowed paths (both in hub config and super-gateway config parsing), and logs the actual error in the proxy `ErrorHandler`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6898bb55d4da7733ce00fd9a910b7f84ae62829e.</sup>
<!-- /MENDRAL_SUMMARY -->