### PR TITLE
chore(deps): bump go-git to 5.19.2 in mcp-hub

### DIFF
--- a/.github/workflows/dependency-verification.yaml
+++ b/.github/workflows/dependency-verification.yaml
@@ -1,8 +1,9 @@
 name: Dependency verification
-# Runs build + tests for the npm sub-projects (servers/, tests/) on dependency
-# bump PRs, so a bumped lockfile is proven to install, compile and pass its
-# smoke tests before merge. Not wired into branch protection: it produces
-# evidence, it does not gate the merge button.
+# Runs build + tests for the npm sub-projects (servers/, tests/) and the
+# root Go module on dependency bump PRs, so a bumped lockfile/go.mod is
+# proven to install, compile and pass its smoke tests before merge. Not
+# wired into branch protection: it produces evidence, it does not gate the
+# merge button.
 on:
   pull_request:
     # `edited` matters: the job re-evaluates when a title is fixed after opening.
@@ -10,12 +11,48 @@ on:
     paths:
       - "servers/**"
       - "tests/**"
+      - "go.mod"
+      - "go.sum"
+      - "**/*.go"
+      - "!super-gateway/**"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  verify-go:
+    # Dependency PRs only: this remediation, Dependabot's own PRs, or an explicit label.
+    if: >-
+      contains(github.event.pull_request.title, 'Dependabot') ||
+      startsWith(github.event.pull_request.title, 'chore(deps)') ||
+      startsWith(github.head_ref, 'cploujoux/devin/dependabot-') ||
+      startsWith(github.head_ref, 'dependabot/') ||
+      contains(github.event.pull_request.labels.*.name, 'dependencies') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Go
+        # Matches the toolchain build-and-push.yaml uses to build and run
+        # this same module (go.mod declares `go 1.25.0`).
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: "1.25.3"
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...
+      - name: Verify go.mod/go.sum are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
+
   verify-servers:
     # Dependency PRs only: this remediation, Dependabot's own PRs, or an explicit label.
     if: >-

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/dop251/goja v0.0.0-20250125213203-5ef83b82af17
-	github.com/go-git/go-git/v5 v5.19.0
+	github.com/go-git/go-git/v5 v5.19.2
 	github.com/joho/godotenv v1.5.1
 	github.com/spf13/cobra v1.8.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
-github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.2 h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
+github.com/go-git/go-git/v5 v5.19.2/go.mod h1:QqCBE1EFN5ddFmrliLQ3/ntRCUjZU3EJuwuB/jWEHjk=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=

--- a/internal/git/clone_test.go
+++ b/internal/git/clone_test.go
@@ -1,0 +1,293 @@
+package git
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/storer"
+)
+
+// testSignature returns a deterministic commit signature for test fixtures.
+func testSignature() object.Signature {
+	return object.Signature{
+		Name:  "mcp-hub-test",
+		Email: "test@example.com",
+		When:  time.Unix(1700000000, 0),
+	}
+}
+
+// writeBlob stores data as a blob object and returns its hash.
+func writeBlob(t *testing.T, s storer.EncodedObjectStorer, data []byte) plumbing.Hash {
+	t.Helper()
+	obj := s.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+	w, err := obj.Writer()
+	if err != nil {
+		t.Fatalf("blob writer: %v", err)
+	}
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("blob write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("blob close: %v", err)
+	}
+	hash, err := s.SetEncodedObject(obj)
+	if err != nil {
+		t.Fatalf("store blob: %v", err)
+	}
+	return hash
+}
+
+// storeRawTree encodes and stores a tree object built from the given entries.
+func storeRawTree(t *testing.T, s storer.EncodedObjectStorer, entries []object.TreeEntry) plumbing.Hash {
+	t.Helper()
+	sort.Sort(object.TreeEntrySorter(entries))
+	tree := &object.Tree{Entries: entries}
+	obj := s.NewEncodedObject()
+	if err := tree.Encode(obj); err != nil {
+		t.Fatalf("encode tree: %v", err)
+	}
+	hash, err := s.SetEncodedObject(obj)
+	if err != nil {
+		t.Fatalf("store tree: %v", err)
+	}
+	return hash
+}
+
+// buildMaliciousCommit builds a commit on top of parent whose tree adds a
+// single nested file at filePath (e.g. "s/config"), containing "exploit".
+// Intermediate path components become real tree (directory) entries — the
+// crafted tree never contains a symlink itself. The symlink is planted
+// separately, directly on disk, exactly as CVE-2026-71556 / GHSA-hc8v-wwc9-vgxm
+// describes: a symlink already present in the worktree, followed by a later
+// worktree operation whose path string is innocent but resolves through it.
+func buildMaliciousCommit(t *testing.T, s storer.Storer, parent *object.Commit, parentHash plumbing.Hash, filePath string) plumbing.Hash {
+	t.Helper()
+
+	leafHash := writeBlob(t, s, []byte("exploit"))
+	mode := filemode.Regular
+
+	parts := strings.Split(filePath, "/")
+	for i := len(parts) - 1; i >= 1; i-- {
+		entry := object.TreeEntry{Name: parts[i], Mode: mode, Hash: leafHash}
+		leafHash = storeRawTree(t, s, []object.TreeEntry{entry})
+		mode = filemode.Dir
+	}
+
+	parentTree, err := parent.Tree()
+	if err != nil {
+		t.Fatalf("parent tree: %v", err)
+	}
+	entries := make([]object.TreeEntry, len(parentTree.Entries), len(parentTree.Entries)+1)
+	copy(entries, parentTree.Entries)
+	entries = append(entries, object.TreeEntry{Name: parts[0], Mode: mode, Hash: leafHash})
+	rootHash := storeRawTree(t, s, entries)
+
+	sig := testSignature()
+	commit := &object.Commit{
+		Author:       sig,
+		Committer:    sig,
+		Message:      "attack: write through masking symlink " + filePath + "\n",
+		TreeHash:     rootHash,
+		ParentHashes: []plumbing.Hash{parentHash},
+	}
+	obj := s.NewEncodedObject()
+	if err := commit.Encode(obj); err != nil {
+		t.Fatalf("encode commit: %v", err)
+	}
+	commitHash, err := s.SetEncodedObject(obj)
+	if err != nil {
+		t.Fatalf("store commit: %v", err)
+	}
+	return commitHash
+}
+
+// newSourceRepo creates a plain git repository on disk with a single commit
+// (a README file) and returns its directory and default branch name.
+func newSourceRepo(t *testing.T) (dir string, branch string) {
+	t.Helper()
+	dir = t.TempDir()
+
+	r, err := gogit.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("init source repo: %v", err)
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		t.Fatalf("source worktree: %v", err)
+	}
+
+	f, err := w.Filesystem.Create("README")
+	if err != nil {
+		t.Fatalf("create README: %v", err)
+	}
+	if _, err := f.Write([]byte("hello\n")); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close README: %v", err)
+	}
+	if _, err := w.Add("README"); err != nil {
+		t.Fatalf("add README: %v", err)
+	}
+	sig := testSignature()
+	if _, err := w.Commit("initial commit\n", &gogit.CommitOptions{Author: &sig}); err != nil {
+		t.Fatalf("initial commit: %v", err)
+	}
+
+	head, err := r.Head()
+	if err != nil {
+		t.Fatalf("source head: %v", err)
+	}
+	return dir, head.Name().Short()
+}
+
+// TestCloneRepository_ClonesSuccessfully proves the go-git 5.19.2 bump did
+// not break basic cloning, the only thing CloneRepository is asked to do in
+// production (hub imports run this exact function against real MCP server
+// repositories).
+func TestCloneRepository_ClonesSuccessfully(t *testing.T) {
+	srcDir, branch := newSourceRepo(t)
+	dstDir := filepath.Join(t.TempDir(), "clone")
+
+	repo, err := CloneRepository(dstDir, branch, srcDir)
+	if err != nil {
+		t.Fatalf("CloneRepository: %v", err)
+	}
+	if repo == nil {
+		t.Fatal("CloneRepository returned a nil repository")
+	}
+
+	data, err := os.ReadFile(filepath.Join(dstDir, "README"))
+	if err != nil {
+		t.Fatalf("read cloned README: %v", err)
+	}
+	if string(data) != "hello\n" {
+		t.Fatalf("unexpected README content: %q", data)
+	}
+
+	if err := DeleteRepository(dstDir); err != nil {
+		t.Fatalf("DeleteRepository: %v", err)
+	}
+	if _, err := os.Stat(dstDir); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to be removed, stat err = %v", dstDir, err)
+	}
+}
+
+// TestCloneRepository_RejectsSymlinkTraversalOnCheckout targets the attack
+// class behind GHSA-hc8v-wwc9-vgxm / CVE-2026-71556 ("go-git: Worktree
+// operations may follow symlinks", fixed in go-git v5.19.2) through
+// mcp-hub's actual production entry point, CloneRepository: plant a
+// masking symlink directly in a cloned worktree, then force-checkout a
+// commit that writes a nested, innocent-looking path ("s/config") through
+// it, and confirm the write lands inside the worktree rather than through
+// the symlink into the repository's real .git.
+//
+// IMPORTANT, read before trusting this as proof of the version bump: this
+// exact scenario, and the two-level-nested variant ("a/b/s/config"), were
+// verified NOT to discriminate go-git v5.19.1 from v5.19.2 for this call
+// pattern. Both versions already defeat it, and for a reason unrelated to
+// the v5.19.2 fix: go-git's Reset/Checkout path does a full worktree-vs-
+// target diff (diffStagingWithWorktree) before writing, and Lstat-ing the
+// planted symlink there finds a type mismatch against the target tree (a
+// leaf where the target expects a directory), which merkletrie reports as
+// Delete("s") + Insert("s/config") rather than a bare Insert. The Delete
+// removes the symlink before the Insert ever calls checkoutFile, so the
+// v5.19.1-only code path this test was meant to catch (checkoutFile's
+// unguarded OpenFile/MkdirAll, the thing v5.19.2's clearBlockingSymlinks
+// exists to guard) is never reached for a single Worktree.Checkout call —
+// verified by disassembling the v5.19.1 test binary (`go tool nm`) to
+// confirm clearBlockingSymlinks/validNoLeadingSymlink are genuinely absent
+// from the linked code, not a stale build.
+//
+// So this test does not prove the v5.19.2 bump changed CloneRepository's
+// behavior — it doesn't, for this call pattern. It is kept anyway as a
+// general regression guard (it would fail if a *future* go-git version, or
+// a switch to a different Worktree entry point such as Add/Remove/
+// submodule updates, reopened this class of bug), and because upstream
+// go-git's own dedicated test suite for this advisory
+// (TestForceCheckoutReplacesLeadingSymlink and
+// TestWorktreeFilesystemRejectsSymlinkTraversal in go-git/go-git's
+// worktree_fs_test.go) is the actual proof the fix works; reproducing
+// *that* would require exercising go-git's internal, unexported
+// worktreeFilesystem type, which is not reachable from mcp-hub as a
+// library consumer.
+func TestCloneRepository_RejectsSymlinkTraversalOnCheckout(t *testing.T) {
+	srcDir, branch := newSourceRepo(t)
+	dstDir := filepath.Join(t.TempDir(), "clone")
+
+	repo, err := CloneRepository(dstDir, branch, srcDir)
+	if err != nil {
+		t.Fatalf("CloneRepository: %v", err)
+	}
+
+	w, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	headCommit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		t.Fatalf("head commit: %v", err)
+	}
+
+	gitConfigPath := filepath.Join(dstDir, ".git", "config")
+	before, err := os.ReadFile(gitConfigPath)
+	if err != nil {
+		t.Fatalf("read .git/config before checkout: %v", err)
+	}
+
+	// Plant the masking symlink directly on disk, as an attacker (or a
+	// leftover from an earlier run) would. "s" -> ".git" resolves, from the
+	// worktree root, to dstDir/.git.
+	if err := w.Filesystem.Symlink(".git", "s"); err != nil {
+		t.Fatalf("plant masking symlink: %v", err)
+	}
+
+	// The attack commit writes "s/config" — an entirely ordinary nested
+	// file from git's point of view.
+	attackHash := buildMaliciousCommit(t, repo.Storer, headCommit, head.Hash(), "s/config")
+
+	if err := w.Checkout(&gogit.CheckoutOptions{Hash: attackHash, Force: true}); err != nil {
+		t.Fatalf("force checkout of attack commit: %v", err)
+	}
+
+	after, err := os.ReadFile(gitConfigPath)
+	if err != nil {
+		t.Fatalf("read .git/config after checkout: %v", err)
+	}
+	if bytes.Contains(after, []byte("exploit")) || !bytes.Equal(before, after) {
+		t.Fatalf(".git/config was modified by checkout through the masking symlink: before=%q after=%q", before, after)
+	}
+
+	// The fix replaces the blocking leading symlink with a real directory
+	// and writes the tracked file safely inside the worktree instead of
+	// erroring outright — matching plain git's own force-checkout
+	// behaviour (create_directories + unlink-before-write).
+	fi, err := os.Lstat(filepath.Join(dstDir, "s"))
+	if err != nil {
+		t.Fatalf("lstat s: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("leading symlink \"s\" was not replaced by a real directory")
+	}
+	data, err := os.ReadFile(filepath.Join(dstDir, "s", "config"))
+	if err != nil {
+		t.Fatalf("read s/config: %v", err)
+	}
+	if string(data) != "exploit" {
+		t.Fatalf("expected checked-out content inside the worktree, got %q", data)
+	}
+}


### PR DESCRIPTION
Fixes ENG-4636

Closes the one open high-severity Dependabot alert on this repo: `github.com/go-git/go-git/v5` 5.19.0 → 5.19.2 (GHSA-hc8v-wwc9-vgxm / CVE-2026-71556, plus GHSA-qgq7-7hm3-q39j moderate, same fix version).

5.19.2 is also the latest release and clears all 12 known go-git advisories as of today.

## What changed

| package | manifest | old → new | severity | advisory |
|---|---|---|---|---|
| github.com/go-git/go-git/v5 | `go.mod` | 5.19.0 → 5.19.2 | high | GHSA-hc8v-wwc9-vgxm |

Only `internal/git/clone.go` imports go-git, with a single caller in `cmd/import.go`. `super-gateway/` is a separate module and is untouched.

## Validation

- `go build ./...`, `go vet ./...`, `go test ./...` green. go.sum carries 5.19.2 with no leftover 5.19.0/5.19.1 entry.
- Read every release note from 5.19.0 to 5.19.2: worktree/submodule/transport hardening only, nothing touching `PlainClone`'s API surface.
- New tests in `internal/git/clone_test.go` exercising `CloneRepository`, the only production path.

## Verification gate

The existing `dependency-verification.yaml` only filtered on `servers/**` and `tests/**`, so a Go dependency PR got no PR-time signal at all (`build-and-push.yaml` covers this module but only on push to develop/main, never on pull_request). This PR adds a `verify-go` job (build, vet, test, `go mod tidy` drift check), gated the same way as the existing jobs so it stays scoped to dependency PRs. `actions/setup-go` pinned to a full SHA.

## Honest limit on the proof

`TestCloneRepository_RejectsSymlinkTraversalOnCheckout` is included as a general regression guard, but it does **not** discriminate 5.19.1 from 5.19.2 for this call pattern, and should not be read as proof the advisory is fixed.

We tried to build that discriminator and could not. A reproduction mirroring go-git's own upstream regression test does not fail on 5.19.1, confirmed by disassembling the compiled test binary with `go tool nm` to check the 5.19.2-only guard functions were genuinely absent rather than a build-cache artifact. Four variants, all already safe. The reason: go-git's Reset/Checkout runs a full worktree-vs-target diff that decomposes the masking symlink into Delete+Insert before the unguarded write path is reached. A go-git-free reproduction against raw `go-billy` osfs *does* escape, so that safety comes from go-git's pre-existing diff logic, not the filesystem layer.

The real proof of the fix lives in upstream go-git's white-box suite, which needs unexported internals we cannot reach as a library consumer. No production path here reaches the gap today, since `CloneRepository` never calls Add/Remove/submodule methods. Worth revisiting if `internal/git` grows to use them.

## Residual risk

`cmd/import.go` has no test coverage of its own. Pre-existing gap, out of scope for this bump. The known `servers/` TypeScript build failure is also untouched and unrelated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/mcp-hub/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Bumps `github.com/go-git/go-git/v5` from 5.19.0 to 5.19.2 to fix GHSA-hc8v-wwc9-vgxm (high: symlink traversal in worktree operations) and GHSA-qgq7-7hm3-q39j (moderate: malicious reference names). Adds regression tests for `CloneRepository` and a new `verify-go` CI job so Go dependency PRs get PR-time build/test/vet signal.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 83e93f0e58189b72205c69830b2cf21e3ba78984.</sup>
<!-- /MENDRAL_SUMMARY -->