### PR TITLE
chore(deps): override js-yaml to 3.15.1 in tests

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -7,7 +7,8 @@
   "pnpm": {
     "overrides": {
       "fast-uri": "3.1.5",
-      "ip-address": "10.3.1"
+      "ip-address": "10.3.1",
+      "js-yaml": "3.15.1"
     }
   },
   "scripts": {
@@ -27,6 +28,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.20.1",
     "fast-uri": "3.1.5",
-    "ip-address": "10.3.1"
+    "ip-address": "10.3.1",
+    "js-yaml": "3.15.1"
   }
 }

--- a/tests/pnpm-lock.yaml
+++ b/tests/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   fast-uri: 3.1.5
   ip-address: 10.3.1
+  js-yaml: 3.15.1
 
 importers:
 
@@ -37,6 +38,9 @@ importers:
       ip-address:
         specifier: 10.3.1
         version: 10.3.1
+      js-yaml:
+        specifier: 3.15.1
+        version: 3.15.1
 
 packages:
 
@@ -712,8 +716,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1226,7 +1230,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -1858,7 +1862,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1

--- a/tests/test/js-yaml.test.js
+++ b/tests/test/js-yaml.test.js
@@ -51,6 +51,22 @@
 // well under a "few hundred MB" memory concern. The timeout is a hang
 // detector, not a performance benchmark: min-of-3 runs guards against a
 // single slow tick reading as a false pass.
+//
+// Considered and rejected: an n-vs-2n scaling-ratio assertion instead of an
+// absolute bound (theoretically machine-speed independent). Measured it
+// directly (best of 5, ms) before deciding:
+//   n=35,000/70,000:   3.15.0 ratio ~3.90x   3.15.1 ratio ~2.06x
+//   n=70,000/140,000:  3.15.0 ratio ~4.14x   3.15.1 ratio ~2.13x
+// A doubling ratio is capped near the O(n^2)-vs-O(n) exponents themselves
+// (~4x vs ~2x), so any threshold between them gets only a ~1.3-1.5x margin
+// on each side - tighter than the absolute bound above, not looser. A
+// bigger multiplier widens it (10x-input ratio measured at ~83-95x
+// vulnerable vs ~4.75-9.25x fixed, still only ~3-4x margins either side of
+// a threshold) but the fixed side's baseline is then only 10-30ms, noisy
+// enough on a shared runner that the ratio itself swings 2x across repeats,
+// and the vulnerable side's 10x-larger pathological input costs 9-18s per
+// run instead of ~9s. The absolute bound above already passed on the real
+// GitHub Actions runner (PR #125, verify-tests, 2026-08-10) - kept it.
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const yaml = require("js-yaml");

--- a/tests/test/js-yaml.test.js
+++ b/tests/test/js-yaml.test.js
@@ -1,0 +1,89 @@
+"use strict";
+
+// Smoke test for the `js-yaml` dependency bump (GHSA-5p4m-2wfm-xmqj), pulled
+// in transitively via @jest/globals -> @jest/expect -> jest-snapshot ->
+// @jest/transform -> babel-plugin-istanbul -> @istanbuljs/load-nyc-config ->
+// js-yaml. That whole chain is Jest's coverage-instrumentation plugin
+// (babel-plugin-istanbul); this project's `test:unit` script runs
+// `node --test`, not Jest, and there is no babel/jest/nyc config anywhere in
+// this package, so the instrumentation code that would call into js-yaml is
+// never actually invoked here. This is dev-only, non-runtime exposure.
+//
+// `js-yaml` is not imported anywhere in this project's own source: it is
+// promoted to an explicit devDependency (pinned to the exact patched
+// version) purely so this test can require() it directly and pin the
+// resolved version, instead of relying on it staying hoisted as a phantom
+// transitive.
+//
+// The advisory: `resolveYamlOmap()` deduplicates `!!omap` keys with
+// `objectKeys.indexOf(pairKey)` inside the per-entry loop, an O(n) scan run
+// once per entry, making the whole resolution O(n^2). A modestly sized
+// YAML `!!omap` document therefore blocks the event loop for seconds inside
+// a plain `yaml.load(untrustedInput)` (default schema, no options needed).
+// This is the same weakness as CVE-2026-59870 (GHSA-724g-mxrg-4qvm), which
+// was fixed in the 5.x line in 5.2.1 but never backported to 3.x/4.x.
+//
+// Fixed in js-yaml@3.15.1: `lib/js-yaml/type/omap.js` replaces the
+// `indexOf`-based array scan with an object-keyed hash lookup, making
+// dedup O(1) per entry (verified via
+// `gh api /repos/nodeca/js-yaml/compare/3.15.0...3.15.1` - the only line
+// changed is that lookup; duplicate-key rejection semantics are preserved).
+//
+// The fix does not change *what* gets accepted or rejected, only how fast -
+// a duplicate key is rejected on both 3.15.0 and 3.15.1, so a
+// correctness-only assertion can't tell them apart. The discriminator is
+// therefore timing, sized so the margin on *both* sides of the threshold is
+// comfortable, not just the ratio between the two regimes. Measured on this
+// machine before writing the assertion (best of 3, ms):
+//   n        3.15.1 (fixed)   3.15.0 (vulnerable)
+//   70,000   ~90-230          ~2,200-2,234
+//   100,000  ~111             ~4,527
+//   140,000  ~148             ~9,090
+//   180,000  ~193             ~15,343
+// which matches the advisory's O(n^2) signature (~4x runtime per doubling of
+// n on 3.15.0, ~1.3-1.7x on the O(1)-lookup 3.15.1). n=70,000 with a 1000ms
+// threshold gave only an ~11x margin above the fixed runtime and ~2.2x below
+// the vulnerable one - too tight for a shared CI runner that can run
+// 2-5x slower than this machine plus a GC pause on top, which would eat
+// most of the fixed side's margin. n=140,000 with a 2000ms threshold gives
+// ~13.5x above the fixed runtime (148ms) and ~4.5x below the vulnerable one
+// (9,090ms) - both margins comfortable, and the doc is still only ~2.3MB /
+// well under a "few hundred MB" memory concern. The timeout is a hang
+// detector, not a performance benchmark: min-of-3 runs guards against a
+// single slow tick reading as a false pass.
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const yaml = require("js-yaml");
+
+function omapDoc(n) {
+	const lines = new Array(n);
+	for (let i = 0; i < n; i += 1) lines[i] = `- k${i}: ${i}`;
+	return `!!omap\n${lines.join("\n")}\n`;
+}
+
+test("js-yaml resolves a large !!omap without quadratic blowup (GHSA-5p4m-2wfm-xmqj)", () => {
+	const doc = omapDoc(140000);
+	let best = Infinity;
+	for (let i = 0; i < 3; i += 1) {
+		const start = Date.now();
+		yaml.load(doc);
+		best = Math.min(best, Date.now() - start);
+	}
+	// Hang detector: fixed version resolves in ~148ms on this machine,
+	// vulnerable 3.15.0 takes ~9.1s for the same input. 2000ms leaves a
+	// comfortable margin on both sides (~13.5x above fixed, ~4.5x below
+	// vulnerable).
+	assert.ok(
+		best < 2000,
+		`omap resolution took ${best}ms for 140k entries, expected well under 2000ms (js-yaml still vulnerable to GHSA-5p4m-2wfm-xmqj?)`,
+	);
+});
+
+test("js-yaml still rejects a duplicate key in an !!omap", () => {
+	assert.throws(() => yaml.load("!!omap\n- a: 1\n- a: 2\n"));
+});
+
+test("js-yaml still parses a well-formed !!omap", () => {
+	const parsed = yaml.load("!!omap\n- a: 1\n- b: 2\n");
+	assert.deepEqual(parsed, [{ a: 1 }, { b: 2 }]);
+});


### PR DESCRIPTION
Fixes ENG-4643

Closes the one remaining high-severity alert on this repo: js-yaml 3.15.0 → 3.15.1 in `tests/` (GHSA-5p4m-2wfm-xmqj, quadratic-complexity DoS on `!!omap` parsing).

This is the 3.x line, not the 4.3.0 → 4.3.1 fix applied elsewhere. The advisory's affected range was widened to cover 3.x, which is why this alert appeared on 2026-08-10 for a lockfile nobody had touched.

## Not a regression from #124

The alert was created one minute after #124 merged, so worth stating plainly: #124 did not cause it. That PR touched only `go.mod`, `go.sum`, the CI workflow and `internal/git/clone_test.go`, never `tests/pnpm-lock.yaml`. The advisory itself was published 2026-08-06, four days earlier. Dependabot simply rescanned on the merge push.

## What changed

| package | manifest | old → new | severity | advisory |
|---|---|---|---|---|
| js-yaml | `tests/package.json` (pnpm override) + `tests/pnpm-lock.yaml` | 3.15.0 → 3.15.1 | high | GHSA-5p4m-2wfm-xmqj |

Applied as a `pnpm.overrides` entry, the same mechanism already used in `tests/` for fast-uri and ip-address. 3.15.1 is the last release of the 3.x line and clears everything known against that branch, so there is no need to jump to 4.x and its unrelated breaking API changes (`safeLoad`/`safeDump` removal).

Diffed 3.15.0...3.15.1 upstream: the only production file touched is `lib/js-yaml/type/omap.js`, swapping a linear `indexOf` scan for a hash lookup. No API surface changed.

## Exposure

Low, and worth being honest about. The chain is `@jest/globals` → `@jest/transform` → `babel-plugin-istanbul` → `@istanbuljs/load-nyc-config` → js-yaml, all dev-scope. There is no Babel, Jest or nyc config anywhere in `tests/`, and `test:unit` runs `node --test test/*.test.js` directly, so the YAML-loading path is never invoked. The override closes it anyway because it costs nothing.

## Test proving it

`tests/test/js-yaml.test.js` parses a 140,000-entry `!!omap` and asserts a best-of-3 time under 2000ms.

The bound was sized from measurements at three input sizes, not guessed:

| n | 3.15.1 (fixed) | 3.15.0 (vulnerable) |
|---|---|---|
| 100,000 | ~111ms | ~4,527ms |
| 140,000 | ~148ms | ~9,090ms |
| 180,000 | ~193ms | ~15,343ms |

A first attempt used 70k entries with a 1000ms bound. That was rejected: it left only ~11x headroom above the fixed runtime and ~2.2x below the vulnerable one, and a shared runner is typically 2-5x slower than a dev machine. Raising the threshold alone would not work either, since the vulnerable runtime at 70k is only ~2.2s. Because the advisory is O(n²), raising `n` widens both margins at once. 140k/2000ms gives ~13.5x above fixed and ~4.5x below vulnerable, with the document still around 2.3MB.

Verified in both directions rather than assumed: swapping 3.15.0 back into `node_modules` makes the test fail at 9,127ms with the intended message. The two functional assertions in the same file (duplicate-key rejection, well-formed parse) pass on both versions, as expected, since the fix changes speed and not accept/reject behaviour.

## Verification gate

No workflow change. The existing `verify-tests` job already runs `pnpm install --frozen-lockfile && pnpm run test:unit` inside `tests/` on dependency PRs, and this branch name matches its job-level condition, so the new test rides it. Full suite is 8/8 green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/mcp-hub/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Overrides `js-yaml` from 3.15.0 to 3.15.1 in `tests/` to address GHSA-5p4m-2wfm-xmqj (quadratic-complexity DoS on `!!omap` parsing), following the existing `pnpm.overrides` pattern. Adds a smoke test that verifies the fix by timing a large omap parse.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 33cf56c5064e26d85b414aa60192458133658ccc.</sup>
<!-- /MENDRAL_SUMMARY -->