### PR TITLE
chore(deps): fix moderate/low Dependabot alerts in mcp-hub

### DIFF
--- a/.github/workflows/dependency-verification.yaml
+++ b/.github/workflows/dependency-verification.yaml
@@ -1,9 +1,10 @@
 name: Dependency verification
-# Runs build + tests for the npm sub-projects (servers/, tests/) and the
-# root Go module on dependency bump PRs, so a bumped lockfile/go.mod is
-# proven to install, compile and pass its smoke tests before merge. Not
-# wired into branch protection: it produces evidence, it does not gate the
-# merge button.
+# Runs build + tests for the npm sub-projects (servers/, tests/), the
+# root Go module and the super-gateway Go module (a separate go.mod, see
+# verify-super-gateway below) on dependency bump PRs, so a bumped
+# lockfile/go.mod is proven to install, compile and pass its smoke tests
+# before merge. Not wired into branch protection: it produces evidence, it
+# does not gate the merge button.
 on:
   pull_request:
     # `edited` matters: the job re-evaluates when a title is fixed after opening.
@@ -11,10 +12,10 @@ on:
     paths:
       - "servers/**"
       - "tests/**"
+      - "super-gateway/**"
       - "go.mod"
       - "go.sum"
       - "**/*.go"
-      - "!super-gateway/**"
   workflow_dispatch:
 
 permissions:
@@ -52,6 +53,45 @@ jobs:
           go mod tidy
           git diff --exit-code go.mod go.sum
 
+  verify-super-gateway:
+    # super-gateway/ is its own Go module (module supergateway, separate
+    # go.mod/go.sum from the repo root) and was previously excluded from this
+    # workflow's trigger paths entirely, so a dependency PR touching only
+    # super-gateway/go.mod got zero PR-time signal. It ships in production
+    # (built via `make build-super-gateway` / `make run`) despite having no
+    # workflow of its own anywhere in this repo.
+    # Dependency PRs only: this remediation, Dependabot's own PRs, or an explicit label.
+    if: >-
+      contains(github.event.pull_request.title, 'Dependabot') ||
+      startsWith(github.event.pull_request.title, 'chore(deps)') ||
+      startsWith(github.head_ref, 'cploujoux/devin/dependabot-') ||
+      startsWith(github.head_ref, 'dependabot/') ||
+      contains(github.event.pull_request.labels.*.name, 'dependencies') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: super-gateway
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Go
+        # Same toolchain pin as verify-go above, for consistency across the
+        # repo's two Go modules.
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: "1.25.3"
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...
+      - name: Verify go.mod/go.sum are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
 
   verify-servers:
     # Dependency PRs only: this remediation, Dependabot's own PRs, or an explicit label.

--- a/servers/package.json
+++ b/servers/package.json
@@ -24,7 +24,10 @@
 		"overrides": {
 			"@modelcontextprotocol/sdk": "1.29.0",
 			"fast-uri": "3.1.5",
-			"ip-address": "10.3.1"
+			"ip-address": "10.3.1",
+			"hono": "4.12.34",
+			"@hono/node-server": "2.0.10",
+			"undici": "6.28.0"
 		}
 	},
 	"dependencies": {

--- a/servers/pnpm-lock.yaml
+++ b/servers/pnpm-lock.yaml
@@ -8,6 +8,9 @@ overrides:
   '@modelcontextprotocol/sdk': 1.29.0
   fast-uri: 3.1.5
   ip-address: 10.3.1
+  hono: 4.12.34
+  '@hono/node-server': 2.0.10
+  undici: 6.28.0
 
 importers:
 
@@ -157,11 +160,11 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
+    engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.34
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -517,8 +520,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.31:
-    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -825,8 +828,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
   unpipe@1.0.0:
@@ -1060,9 +1063,9 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@hono/node-server@1.19.14(hono@4.12.31)':
+  '@hono/node-server@2.0.10(hono@4.12.34)':
     dependencies:
-      hono: 4.12.31
+      hono: 4.12.34
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -1075,7 +1078,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.31)
+      '@hono/node-server': 2.0.10(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -1085,7 +1088,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.0(express@5.2.1)
-      hono: 4.12.31
+      hono: 4.12.34
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -1110,7 +1113,7 @@ snapshots:
     dependencies:
       '@qdrant/openapi-typescript-fetch': 1.2.6
       typescript: 5.9.3
-      undici: 6.27.0
+      undici: 6.28.0
 
   '@qdrant/openapi-typescript-fetch@1.2.6': {}
 
@@ -1454,7 +1457,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.31: {}
+  hono@4.12.34: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -1760,7 +1763,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@6.27.0: {}
+  undici@6.28.0: {}
 
   unpipe@1.0.0: {}
 

--- a/super-gateway/go.mod
+++ b/super-gateway/go.mod
@@ -1,10 +1,10 @@
 module supergateway
 
-go 1.21
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.1
 )
 
-require golang.org/x/net v0.17.0 // indirect
+require golang.org/x/net v0.56.0 // indirect

--- a/super-gateway/go.sum
+++ b/super-gateway/go.sum
@@ -2,5 +2,5 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
-golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,7 +8,9 @@
     "overrides": {
       "fast-uri": "3.1.5",
       "ip-address": "10.3.1",
-      "js-yaml": "3.15.1"
+      "js-yaml": "3.15.1",
+      "hono": "4.12.34",
+      "@hono/node-server": "2.0.10"
     }
   },
   "scripts": {

--- a/tests/pnpm-lock.yaml
+++ b/tests/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   fast-uri: 3.1.5
   ip-address: 10.3.1
   js-yaml: 3.15.1
+  hono: 4.12.34
+  '@hono/node-server': 2.0.10
 
 importers:
 
@@ -206,11 +208,11 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
+    engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.34
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -621,8 +623,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.31:
-    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -1221,9 +1223,9 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@hono/node-server@1.19.14(hono@4.12.31)':
+  '@hono/node-server@2.0.10(hono@4.12.34)':
     dependencies:
-      hono: 4.12.31
+      hono: 4.12.34
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -1325,7 +1327,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.31)
+      '@hono/node-server': 2.0.10(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -1335,7 +1337,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.0(express@5.2.1)
-      hono: 4.12.31
+      hono: 4.12.34
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -1720,7 +1722,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.31: {}
+  hono@4.12.34: {}
 
   http-errors@2.0.1:
     dependencies:


### PR DESCRIPTION
Closes all 17 open moderate/low Dependabot alerts in this repo: **hono, @hono/node-server, undici, golang.org/x/net** across `servers/`, `tests/` and `super-gateway/`.

6 package/manifest groups closed / 0 skipped / 0 blocked / 0 deferred.

**This is a moderate/low PR, so read the evidence bar first.** Moderate and low alerts are held to a lighter standard than critical/high: advisory cleared and verified in the lockfile, build and tests green, and a dedicated test only where the package is reachable from production code on a major or cascading bump. Each row below carries the reachability check that justifies the lighter bar.

| package | bump | reachable from prod? |
|---|---|---|
| hono (servers + tests) | 4.12.31 to 4.12.34 | no, backs the MCP SDK's *server-side* HTTP transport, which this repo never instantiates |
| @hono/node-server (servers + tests) | 1.19.14 to 2.0.10, **major** | no, same reachability, and the repo already requires Node >=22 so the engines bump is a no-op |
| undici (servers) | 6.27.0 to 6.28.0 | **yes**, via `@qdrant/js-client-rest` in the qdrant MCP server, but a same-major minor |
| golang.org/x/net (super-gateway) | 0.17.0 to 0.56.0 | partially, only `x/net/proxy` is imported and nothing here configures a SOCKS5 dialer. The advisories' surface (HTTP/2 frames, HTML parser) is not imported at all |

`grep -rn "StreamableHTTPServerTransport" servers/src tests/src` matches nothing. Only `StdioServerTransport` and the *client* transport are constructed.

## The workflow would not have run on this PR

`dependency-verification.yaml` carried an explicit `!super-gateway/**` exclusion in its `paths:` filter, left by the previous sweep which deliberately scoped itself to the root module. This PR touches `super-gateway/`, so with that exclusion in place the whole workflow would have been skipped on its own diff, and skipped reads as green.

The exclusion is replaced with a positive `super-gateway/**` entry, and a new `verify-super-gateway` job runs build, vet, test and a go.mod/go.sum tidiness check. That module had **no CI at all** before this PR.

## What was verified

- Every package: single resolved copy at the target version (`pnpm why`, `go.sum`), frozen installs clean.
- `servers/`: build green, 5/5 tests. `tests/`: 8/8 unit tests, including the regression tests from the previous sweep. `super-gateway/`: build, vet and 4/4 tests green before and after, `go mod tidy` idempotent.
- Advisory lists pulled from OSV per package rather than only from our tracker. That surfaced two advisories not yet tracked here (`@hono/node-server` GHSA-9mqv-5hh9-4cgg and x/net GO-2026-5942); the chosen targets clear those too.
- Lockfile diffs stayed proportional: 33 lines in `servers/`, 24 in `tests/`, no re-resolution.

## Residual risk

- hono and `@hono/node-server` are verified to compile, not to run, because nothing in this repo runs them. If an HTTP-transport MCP server is ever adopted here, redo that reachability check and add the smoke test this PR skipped.
- Same shape for `x/net/proxy`.
- The known pre-existing TypeScript OOM annotation on `verify-servers` still applies. It did not reproduce locally with the same `NODE_OPTIONS` the job sets, and nothing in this PR touches it.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/mcp-hub/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Bumps transitive dependencies (hono, @hono/node-server, undici, golang.org/x/net) via pnpm overrides and go.mod changes to clear moderate/low Dependabot alerts across servers/, tests/, and super-gateway/. Adds a new CI job (`verify-super-gateway`) to the dependency verification workflow to cover the previously-excluded super-gateway Go module.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f5b95e35cdfb370ffb4bb4384abfd11c65615051.</sup>
<!-- /MENDRAL_SUMMARY -->