### PR TITLE
fix(build): pin typescript to 5.7.3 to unblock the image build

### DIFF
--- a/.github/workflows/dependency-verification.yaml
+++ b/.github/workflows/dependency-verification.yaml
@@ -28,6 +28,8 @@ jobs:
       contains(github.event.pull_request.title, 'Dependabot') ||
       startsWith(github.event.pull_request.title, 'chore(deps)') ||
       startsWith(github.head_ref, 'cploujoux/devin/dependabot-') ||
+      startsWith(github.head_ref, 'cploujoux/dependabot') ||
+      startsWith(github.head_ref, 'cploujoux/fix-mcp-hub-') ||
       startsWith(github.head_ref, 'dependabot/') ||
       contains(github.event.pull_request.labels.*.name, 'dependencies') ||
       github.event_name == 'workflow_dispatch'
@@ -65,6 +67,8 @@ jobs:
       contains(github.event.pull_request.title, 'Dependabot') ||
       startsWith(github.event.pull_request.title, 'chore(deps)') ||
       startsWith(github.head_ref, 'cploujoux/devin/dependabot-') ||
+      startsWith(github.head_ref, 'cploujoux/dependabot') ||
+      startsWith(github.head_ref, 'cploujoux/fix-mcp-hub-') ||
       startsWith(github.head_ref, 'dependabot/') ||
       contains(github.event.pull_request.labels.*.name, 'dependencies') ||
       github.event_name == 'workflow_dispatch'
@@ -99,6 +103,8 @@ jobs:
       contains(github.event.pull_request.title, 'Dependabot') ||
       startsWith(github.event.pull_request.title, 'chore(deps)') ||
       startsWith(github.head_ref, 'cploujoux/devin/dependabot-') ||
+      startsWith(github.head_ref, 'cploujoux/dependabot') ||
+      startsWith(github.head_ref, 'cploujoux/fix-mcp-hub-') ||
       startsWith(github.head_ref, 'dependabot/') ||
       contains(github.event.pull_request.labels.*.name, 'dependencies') ||
       github.event_name == 'workflow_dispatch'
@@ -160,6 +166,8 @@ jobs:
       contains(github.event.pull_request.title, 'Dependabot') ||
       startsWith(github.event.pull_request.title, 'chore(deps)') ||
       startsWith(github.head_ref, 'cploujoux/devin/dependabot-') ||
+      startsWith(github.head_ref, 'cploujoux/dependabot') ||
+      startsWith(github.head_ref, 'cploujoux/fix-mcp-hub-') ||
       startsWith(github.head_ref, 'dependabot/') ||
       contains(github.event.pull_request.labels.*.name, 'dependencies') ||
       github.event_name == 'workflow_dispatch'

--- a/servers/package.json
+++ b/servers/package.json
@@ -18,7 +18,7 @@
 		"fast-uri": "3.1.5",
 		"form-data": "^4.0.4",
 		"ip-address": "10.3.1",
-		"typescript": "^5.9.3"
+		"typescript": "5.7.3"
 	},
 	"pnpm": {
 		"overrides": {

--- a/servers/pnpm-lock.yaml
+++ b/servers/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         version: 0.6.2(zod@3.25.76)
       '@qdrant/js-client-rest':
         specifier: ^1.18.0
-        version: 1.18.0(typescript@5.9.3)
+        version: 1.18.0(typescript@5.7.3)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -51,7 +51,7 @@ importers:
         version: 3.4.9
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@24.13.3)(typescript@5.9.3)
+        version: 10.9.2(@types/node@24.13.3)(typescript@5.7.3)
       twilio:
         specifier: ^5.13.1
         version: 5.13.1
@@ -75,8 +75,8 @@ importers:
         specifier: 10.3.1
         version: 10.3.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: 5.7.3
+        version: 5.7.3
 
 packages:
 
@@ -817,8 +817,8 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1109,10 +1109,10 @@ snapshots:
       - supports-color
       - zod
 
-  '@qdrant/js-client-rest@1.18.0(typescript@5.9.3)':
+  '@qdrant/js-client-rest@1.18.0(typescript@5.7.3)':
     dependencies:
       '@qdrant/openapi-typescript-fetch': 1.2.6
-      typescript: 5.9.3
+      typescript: 5.7.3
       undici: 6.28.0
 
   '@qdrant/openapi-typescript-fetch@1.2.6': {}
@@ -1718,7 +1718,7 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  ts-node@10.9.2(@types/node@24.13.3)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@24.13.3)(typescript@5.7.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -1732,7 +1732,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 5.7.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -1757,7 +1757,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript@5.9.3: {}
+  typescript@5.7.3: {}
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
Fixes ENG-4805

`MCP hub Build and Push` is red on `main`: 14 of the MCP images fail with **JavaScript heap out of memory**, `tsc` blowing through a 12 GB V8 heap.

## This is not the dependency PR's fault, but that PR is what exposed it

The same build failed the same way on **2026-08-05** and **2026-08-10**, on the same servers. Each time the next run went green — because Docker layer caching skipped the `tsc` step entirely. #126 changed the lockfiles, invalidated that cache, forced a cold build, and the latent failure surfaced.

So it has been broken for at least ten days; we were shipping images off a cache that hid it.

## Root cause: a TypeScript regression

Bisected on this repo's actual `servers/` module:

| TypeScript | result |
|---|---|
| **5.7.3** | type-checks in **1.1s**, 446 MB, 1824 files, 0 errors |
| 5.8.3 | still running at 150s, killed |
| 5.9.3 | OOMs after ~324s, 7.5 GB RSS |

`skipLibCheck` was already enabled, so the usual lever was already pulled. What 5.8+ chokes on is this module's combined type surface: aws-sdk s3 + ses, openai, twilio, qdrant, and the MCP SDK all in one program.

## The fix

Pin `servers/` to an **exact** `5.7.3`. A caret range resolves straight back to 5.9 and brings the failure with it.

## Verified

- `pnpm run build` completes in 1.5s locally, no errors
- `--extendedDiagnostics` confirms it really checks everything (1824 files, 365k lines of definitions, 46k types) rather than exiting early
- The Dockerfile's build step now succeeds instead of OOMing

## Left alone on purpose

`custom/code-mode` stays on `^5.9.3`. It is not part of this image build and has not failed. Worth revisiting on its own rather than widening a hotfix.

Longer term this module probably wants its type-check split up, so one 56-file package isn't loading every vendor SDK's types into a single program. That's a refactor, not a fix for a red `main`.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds two branch-name prefixes to the dependency-verification workflow's `if:` conditions (repeated across four jobs) so the verification gate actually executes on this PR and future `cploujoux/dependabot*` or `cploujoux/fix-mcp-hub-*` branches. The TypeScript pin from the first commit is unchanged.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 908e33e678194ac75c40291f7e9dabee0291aa00.</sup>
<!-- /MENDRAL_SUMMARY -->