### PR TITLE
chore: update Discord invite to permanent link

### DIFF
--- a/custom/code-mode/README.md
+++ b/custom/code-mode/README.md
@@ -194,7 +194,7 @@ If you need help with this template:
 - [Submit an issue](https://github.com/blaxel-templates/template-mcp-ts/issues) for bug reports or feature requests
 - Visit the [Blaxel Documentation](https://docs.blaxel.ai) for platform guidance
 - Check the [Model Context Protocol Documentation](https://modelcontextprotocol.io/) for protocol specifications
-- Join our [Discord Community](https://discord.gg/G3NqzUPcHP) for real-time assistance
+- Join our [Discord Community](https://discord.gg/CsWKUZUHFQ) for real-time assistance
 
 ## 📄 License
 


### PR DESCRIPTION
Fixes ENG-4895

Replaces the outdated Discord invite(s) with the new permanent, non-expiring invite: https://discord.gg/CsWKUZUHFQ

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces an expired Discord invite link with a new permanent one in the code-mode README.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ef0bdbaf6c2c4b9d46a37cb4b2b815c00a3d5d8a.</sup>
<!-- /MENDRAL_SUMMARY -->